### PR TITLE
Searchコンポーネントのテストを修正

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ function App() {
   );
 }
 
-function Search({ value, onChange, children }) {
+export function Search({ value, onChange, children }) {
   return (
     <div>
       <label htmlFor="search">{children}</label>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
-import Search from './App';
+import { Search }  from './App';
 
 
 let container;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -48,13 +48,8 @@ describe('Search', () => {
       </Search>, container
     );
 
-    await act(async () => await userEvent.type(screen.getByRole('textbox'), 'JavaScript'))
-    // await userEvent.type(screen.getByRole('textbox'), 'JavaScript');
-    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(10));
-    // screen.debug();
-    // console.log(screen.getByRole('textbox'));
-
-    // expect(onChange).toHaveBeenCalledTimes(10);
+    userEvent.type(screen.getByRole('textbox'), 'JavaScript');
+    expect(onChange).toHaveBeenCalledTimes(10);
   });
 });
 


### PR DESCRIPTION
# TL;DR

- `Search` コンポーネントがexportされていなかった。テストでは `App` が参照されていた
- actやwaitForは不要になった